### PR TITLE
scipy.ndimage import namespace

### DIFF
--- a/convex_adam_MIND.py
+++ b/convex_adam_MIND.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import numpy as np
-from scipy.ndimage.interpolation import zoom as zoom
+from scipy.ndimage import zoom as zoom
 from scipy.ndimage import distance_transform_edt as edt
 from convex_adam_utils import *
 import time


### PR DESCRIPTION
This PR changes the import namespace from `scipy.ndimage.interpolation` to `scipy.ndimage`, based on the deprecation warning:

```
DeprecationWarning: Please use `zoom` from the `scipy.ndimage` namespace, the `scipy.ndimage.interpolation` namespace is deprecated.
```